### PR TITLE
add support for finnix isos on grub2

### DIFF
--- a/data/multibootusb/grub/menus/finnix.d/live-generic.cfg
+++ b/data/multibootusb/grub/menus/finnix.d/live-generic.cfg
@@ -1,0 +1,14 @@
+for isofile in $isopath/finnix-*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname (loopback.cfg) ->" "$isofile" {
+      iso_path="$2"
+      export iso_path
+      search --set=root --file "$iso_path"
+      loopback loop "$iso_path"
+      root=(loop)
+      configfile /boot/grub/loopback.cfg
+      loopback --delete loop
+    }
+  fi
+done


### PR DESCRIPTION
Attempting to pull in existing PRs from the primary GitHub project. This one should add finnix iso support on grub2 according to [lpalgarvio](https://github.com/lpalgarvio)