### PR TITLE
add support for newer systemrescuecd isos on grub2

### DIFF
--- a/data/multibootusb/grub/menus/systemrescuecd.d/generic-new.cfg
+++ b/data/multibootusb/grub/menus/systemrescuecd.d/generic-new.cfg
@@ -1,0 +1,78 @@
+for isofile in $isopath/systemrescue-*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname ->" "$isofile" {
+      iso_path="$2"
+      loopback loop "$iso_path"
+      menuentry "Default boot options" {
+        bootoptions="isoloop=$iso_path scandelay=1"
+        if cpuid -l; then # Check whether CPU is 64-bit
+          linux (loop)/sysresccd/boot/x86_64/vmlinuz $bootoptions
+        else
+          linux (loop)/sysresccd/boot/i686/vmlinuz $bootoptions
+        fi
+        initrd (loop)/sysresccd/boot/intel_ucode.img /sysresccd/boot/amd_ucode.img /sysresccd/boot/x86_64/sysresccd.img
+      }
+      menuentry "All files cached to memory (docache)" {
+        bootoptions="isoloop=$iso_path docache"
+        if cpuid -l; then # Check whether CPU is 64-bit
+          linux (loop)/sysresccd/boot/x86_64/vmlinuz $bootoptions
+        else
+          linux (loop)/sysresccd/boot/i686/vmlinuz $bootoptions
+        fi
+        initrd (loop)/sysresccd/boot/intel_ucode.img /sysresccd/boot/amd_ucode.img /sysresccd/boot/x86_64/sysresccd.img
+      }
+      menuentry "Framebuffer console in high resolution" {
+        bootoptions="isoloop=$iso_path nomodeset vga=791"
+        if cpuid -l; then # Check whether CPU is 64-bit
+          linux (loop)/sysresccd/boot/x86_64/vmlinuz $bootoptions
+        else
+          linux (loop)/sysresccd/boot/i686/vmlinuz $bootoptions
+        fi
+        initrd (loop)/sysresccd/boot/intel_ucode.img /sysresccd/boot/amd_ucode.img /sysresccd/boot/x86_64/sysresccd.img
+      }
+      menuentry "Do not ask for keyboard, use US keymap" {
+        bootoptions="isoloop=$iso_path setkmap=us"
+        if cpuid -l; then # Check whether CPU is 64-bit
+          linux (loop)/sysresccd/boot/x86_64/vmlinuz $bootoptions
+        else
+          linux (loop)/sysresccd/boot/i686/vmlinuz $bootoptions
+        fi
+        initrd (loop)/sysresccd/boot/intel_ucode.img /sysresccd/boot/amd_ucode.img /sysresccd/boot/x86_64/sysresccd.img
+      }
+      menuentry "Boot an existing Linux system installed on the disk" {
+        bootoptions="isoloop=$iso_path root=auto"
+        if cpuid -l; then # Check whether CPU is 64-bit
+          linux (loop)/sysresccd/boot/x86_64/vmlinuz $bootoptions
+        else
+          linux (loop)/sysresccd/boot/i686/vmlinuz $bootoptions
+        fi
+        initrd (loop)/sysresccd/boot/intel_ucode.img /sysresccd/boot/amd_ucode.img /sysresccd/boot/x86_64/sysresccd.img
+      }
+      menuentry "Alternative kernel with default boot options" {
+        bootoptions="isoloop=$iso_path scandelay=1"
+        if cpuid -l; then # Check whether CPU is 64-bit
+          linux (loop)/isolinux/altker64 $bootoptions
+        else
+          linux (loop)/isolinux/altker32 $bootoptions
+        fi
+        initrd (loop)/sysresccd/boot/intel_ucode.img /sysresccd/boot/amd_ucode.img /sysresccd/boot/x86_64/sysresccd.img
+      }
+      menuentry "Directly start the graphical environment" {
+        bootoptions="isoloop=$iso_path dostartx"
+        if cpuid -l; then # Check whether CPU is 64-bit
+          linux (loop)/sysresccd/boot/x86_64/vmlinuz $bootoptions
+        else
+          linux (loop)/sysresccd/boot/i686/vmlinuz $bootoptions
+        fi
+        initrd (loop)/sysresccd/boot/intel_ucode.img /sysresccd/boot/amd_ucode.img /sysresccd/boot/x86_64/sysresccd.img
+      }
+      submenu "System Tools ->" {
+        menuentry "MEMTEST: Memory test using Memtest86+" {
+          bootoptions="-"
+          linux16 (loop)/sysresccd/boot/memtest $bootoptions
+        }
+      }
+    }
+  fi
+done


### PR DESCRIPTION
Attempting to pull in existing PRs from the primary GitHub project. This one should add systemrescuecd iso support on grub2 according to [lpalgarvio](https://github.com/lpalgarvio)